### PR TITLE
Software Architecture Rework

### DIFF
--- a/ElectricalCircuitSimulator/ElectricalCircuitSimulator/MainWindow.xaml.cs
+++ b/ElectricalCircuitSimulator/ElectricalCircuitSimulator/MainWindow.xaml.cs
@@ -478,7 +478,7 @@ namespace ElectricalCircuitSimulator
 
         #region Data Members
 
-        public bool m_bTestMode; // Unit testing mode
+        private bool m_bTestMode; // Unit testing mode
         private double m_dStepSize;
         private double m_dStopTime;
         private LineSeries m_oLineSeriesV;

--- a/ElectricalCircuitSimulator/SimulationEngine/include/Capacitor.h
+++ b/ElectricalCircuitSimulator/SimulationEngine/include/Capacitor.h
@@ -9,7 +9,7 @@ namespace SimulationEngine {
 
         public:
 
-            Capacitor(const int iNodeS, const int iNodeD, const double m_dCapacitance);
+            Capacitor(const size_t iNodeS, const size_t iNodeD, const double m_dCapacitance);
 
             void initalize(Matrix& oConductanceMatrix, const double dTimeStep);
             void step(Matrix& oSourceVector); // Trapezoidal integration

--- a/ElectricalCircuitSimulator/SimulationEngine/include/CircuitComponent.h
+++ b/ElectricalCircuitSimulator/SimulationEngine/include/CircuitComponent.h
@@ -9,15 +9,15 @@ namespace SimulationEngine {
 
         public:
 
-            CircuitComponent(const int iNodeS, const int iNodeD, bool bIsGround);
+            CircuitComponent(const size_t iNodeS, const size_t iNodeD, bool bIsGround);
 
             bool getIsGround() const {
                 return m_bIsGround;
             }
-            int getNodeS() const {
+            size_t getNodeS() const {
                 return m_iNodeS;
             }
-            int getNodeD() const {
+            size_t getNodeD() const {
                 return m_iNodeD;
             }
             double getCurrent() const {
@@ -33,8 +33,8 @@ namespace SimulationEngine {
             virtual void applySourceVectorMatrixStamp(Matrix& oSourceVector);
 
             bool m_bIsGround;
-            int m_iNodeS; // Source
-            int m_iNodeD; // Destination
+            size_t m_iNodeS; // Source
+            size_t m_iNodeD; // Destination
             double m_dComponentResistanceStamp;
             double m_dCurrent; // Current is positive if flowing from source to destination, negative if the opposite direction
     };

--- a/ElectricalCircuitSimulator/SimulationEngine/include/GroundedVoltageSource.h
+++ b/ElectricalCircuitSimulator/SimulationEngine/include/GroundedVoltageSource.h
@@ -9,7 +9,7 @@ namespace SimulationEngine {
 
         public:
 
-            GroundedVoltageSource(const int iNodeS, const int iNodeD, const double dVoltage, const double dResistance); // iNodeS is assumed to be ground
+            GroundedVoltageSource(const size_t iNodeS, const size_t iNodeD, const double dVoltage, const double dResistance); // iNodeS is assumed to be ground
 
             void initalize(Matrix& oConductanceMatrix, const double dTimeStep);
             void step(Matrix& oSourceVector);

--- a/ElectricalCircuitSimulator/SimulationEngine/include/Inductor.h
+++ b/ElectricalCircuitSimulator/SimulationEngine/include/Inductor.h
@@ -9,7 +9,7 @@ namespace SimulationEngine {
 
         public:
 
-            Inductor(const int iNodeS, const int iNodeD, const double m_dInductance);
+            Inductor(const size_t iNodeS, const size_t iNodeD, const double m_dInductance);
 
             void initalize(Matrix& oConductanceMatrix, const double dTimeStep);
             void step(Matrix& oSourceVector); // Trapezoidal integration

--- a/ElectricalCircuitSimulator/SimulationEngine/include/LinearCircuit.h
+++ b/ElectricalCircuitSimulator/SimulationEngine/include/LinearCircuit.h
@@ -4,39 +4,37 @@
 #include "CircuitComponent.h"
 #include <vector>
 
-using std::vector;
-
 namespace SimulationEngine {
 
-    class LinearCircuit {
+    class LinearCircuit final {
 
         public:
 
-            LinearCircuit(const int iNumComponents);
+            LinearCircuit(const size_t iNumComponents);
 
-            ~LinearCircuit();
-
-            int addComponent(CircuitComponent* pCircuitComponent);
+            size_t addComponent(std::unique_ptr<CircuitComponent> pCircuitComponent);
             void setStopTime(const double dStopTime);
             void setTimeStep(const double dTimeStep);
             double getTime() const;
-            double getVoltage(const int iNode) const;
-            double getCurrent(const int iComponentIndex) const;
+            double getVoltage(const size_t iNode) const;
+            double getCurrent(const size_t iComponentIndex) const;
             void initalize();
             bool step();
 
         private:
 
-            CircuitComponent** m_pCircuitComponents;
-            Matrix* m_pConductanceMatrix;
-            Matrix* m_pSourceVector;
-            Matrix* m_pVoltageMatrix;
-            PLU_Factorization* m_pPLU_Factorization;
-            vector<int> m_oNodeList;
-            int m_iMaxComponentCount;
-            int m_iComponentCount;
-            int m_iMaxNode;
-            int m_iGroundNode;
+            void solver();
+
+            std::unique_ptr<std::unique_ptr<CircuitComponent>[]> m_pCircuitComponents;
+            std::unique_ptr<Matrix> m_pConductanceMatrix;
+            std::unique_ptr<Matrix> m_pSourceVector;
+            std::unique_ptr<Matrix> m_pVoltageVector;
+            std::unique_ptr<PLU_Factorization> m_pPLU;
+            std::vector<size_t> m_oNodeList;
+            size_t m_iMaxComponentCount;
+            size_t m_iComponentCount;
+            size_t m_iMaxNode;
+            size_t m_iGroundNode;
             double m_dStopTime;
             double m_dTimeStep;
             double m_dTime;

--- a/ElectricalCircuitSimulator/SimulationEngine/include/Matrix.h
+++ b/ElectricalCircuitSimulator/SimulationEngine/include/Matrix.h
@@ -2,6 +2,8 @@
 #define MATRIX_H
 
 #include <iostream>
+#include <string>
+#include <memory>
 
 namespace SimulationEngine {
 
@@ -9,65 +11,77 @@ namespace SimulationEngine {
     class Matrix;
 
     // All indexes in this class are zero-based
-    class Matrix
+    class Matrix final
     {
         public:
 
-            Matrix() {
-                m_iNumRows = 0;
-                m_iNumColumns = 0;
-                m_oMatrix = new double* [0];
-            };
-            Matrix(const int iRows, const int iColumns);
+            Matrix();
+            Matrix(const size_t iRows, const size_t iColumns);
+            Matrix(const Matrix& oMatrix);
+            Matrix(Matrix&&) = delete;
 
             ~Matrix() {
-                delete m_oMatrix;
+                delete m_pMatrix;
             }
 
-            int getNumRows() const { 
+            Matrix& operator=(const Matrix&) = delete;
+            Matrix& operator=(Matrix&&) = delete;
+            const double& operator()(const size_t iRow, const size_t iColumn) const {
+                return m_pMatrix[iRow][iColumn];
+            }
+            double& operator()(const size_t iRow, const size_t iColumn) {
+                return m_pMatrix[iRow][iColumn];
+            }
+
+            size_t getNumRows() const {
                 return m_iNumRows;
             }
-            int getNumColumns() const {
+            size_t getNumColumns() const {
                 return m_iNumColumns;
             }
-            double getValue(const int iRow, const int iColumn) const;
-            void setValue(const int iRow, const int iColumn, const double dValue);
+            double getValue(const size_t iRow, const size_t iColumn) const;
+            void setValue(const size_t iRow, const size_t iColumn, const double dValue);
+            void swapRows(const size_t iRow1, const size_t iRow2);
+            void swapValues(const size_t iRow1, const size_t iColumn1, const size_t iRow2, const size_t iColumn2);
             void clear();
-            Matrix* clone() const;
-            void printMatrix() const;
-            PLU_Factorization* runPLU_Factorization() const;
-            static Matrix* linearSystemSolver(const Matrix& oSourceVector, const PLU_Factorization& oPLU_Factorization);
+            const std::string printMatrix() const;
 
         private:
 
-            int m_iNumRows;
-            int m_iNumColumns;
-            double** m_oMatrix; // Outer pointer is rows, inner pointer is columns
+            size_t m_iNumRows;
+            size_t m_iNumColumns;
+            double** m_pMatrix; // Outer pointer is rows, inner pointer is columns
     };
 
     // Represents a matrix factored into P*A*Q = L*U, where P = Row Permutation Matrix, and Q = Column Permutation Matrix
-    class PLU_Factorization
+    class PLU_Factorization final
     {
         public:
 
-            PLU_Factorization() {
-                m_pL = new Matrix();
-                m_pU = new Matrix();
-                m_pP = new Matrix();
-                m_pQ = new Matrix();
-            };
+            PLU_Factorization();
+            PLU_Factorization(const Matrix& oMatrix);
 
-            ~PLU_Factorization() {
-                delete m_pL;
-                delete m_pU;
-                delete m_pP;
-                delete m_pQ;
-            };
+            const Matrix& getL() const {
+                return *m_pL;
+            }
+            const Matrix& getU() const {
+                return *m_pU;
+            }
+            const Matrix& getP() const {
+                return *m_pP;
+            }
+            const Matrix& getQ() const {
+                return *m_pQ;
+            }
 
-            Matrix* m_pL; // Lower triangular matrix
-            Matrix* m_pU; // Upper triangular matrix
-            Matrix* m_pP; // Row permutation matrix
-            Matrix* m_pQ; // Column permutation matrix
+        private:
+
+            void runPLU_Factorization(const Matrix& oMatrix);
+
+            std::unique_ptr<Matrix> m_pL; // Lower triangular matrix
+            std::unique_ptr<Matrix> m_pU; // Upper triangular matrix
+            std::unique_ptr<Matrix> m_pP; // Row permutation matrix
+            std::unique_ptr<Matrix> m_pQ; // Column permutation matrix
     };
 
 }

--- a/ElectricalCircuitSimulator/SimulationEngine/include/Resistor.h
+++ b/ElectricalCircuitSimulator/SimulationEngine/include/Resistor.h
@@ -9,7 +9,7 @@ namespace SimulationEngine {
 
         public:
 
-            Resistor(const int iNodeS, const int iNodeD, const double dResistance);
+            Resistor(const size_t iNodeS, const size_t iNodeD, const double dResistance);
 
             void initalize(Matrix& oConductanceMatrix, const double dTimeStep);
             void postStep(Matrix& oVoltageMatrix);

--- a/ElectricalCircuitSimulator/SimulationEngine/src/Capacitor.cpp
+++ b/ElectricalCircuitSimulator/SimulationEngine/src/Capacitor.cpp
@@ -18,14 +18,15 @@ using std::invalid_argument;
 
 namespace SimulationEngine {
 
-    Capacitor::Capacitor(const int iNodeS, const int iNodeD, const double dCapacitance)
-    : CircuitComponent(iNodeS, iNodeD, false) {
+    Capacitor::Capacitor(const size_t iNodeS, const size_t iNodeD, const double dCapacitance) :
+        CircuitComponent(iNodeS, iNodeD, false),
+        m_dVoltageDelta(0)
+    {
         if (dCapacitance <= 0) {
             cout << "Capacitance value must be greater than 0!" << endl;
             throw invalid_argument("Capacitance value must be greater than 0!");
         }
         m_dCapacitance = dCapacitance;
-        m_dVoltageDelta = 0;
     }
 
     void Capacitor::initalize(Matrix& oConductanceMatrix, const double dTimeStep) {
@@ -39,17 +40,17 @@ namespace SimulationEngine {
 
         m_dComponentResistanceStamp = (2.0 * m_dCapacitance) / dTimeStep;
 
-        dResistance = oConductanceMatrix.getValue(m_iNodeS, m_iNodeS);
-        oConductanceMatrix.setValue(m_iNodeS, m_iNodeS, dResistance + m_dComponentResistanceStamp);
+        dResistance = oConductanceMatrix(m_iNodeS, m_iNodeS);
+        oConductanceMatrix(m_iNodeS, m_iNodeS) = dResistance + m_dComponentResistanceStamp;
 
-        dResistance = oConductanceMatrix.getValue(m_iNodeS, m_iNodeD);
-        oConductanceMatrix.setValue(m_iNodeS, m_iNodeD, dResistance - m_dComponentResistanceStamp);
+        dResistance = oConductanceMatrix(m_iNodeS, m_iNodeD);
+        oConductanceMatrix(m_iNodeS, m_iNodeD) = dResistance - m_dComponentResistanceStamp;
 
-        dResistance = oConductanceMatrix.getValue(m_iNodeD, m_iNodeS);
-        oConductanceMatrix.setValue(m_iNodeD, m_iNodeS, dResistance - m_dComponentResistanceStamp);
+        dResistance = oConductanceMatrix(m_iNodeD, m_iNodeS);
+        oConductanceMatrix(m_iNodeD, m_iNodeS) = dResistance - m_dComponentResistanceStamp;
 
-        dResistance = oConductanceMatrix.getValue(m_iNodeD, m_iNodeD);
-        oConductanceMatrix.setValue(m_iNodeD, m_iNodeD, dResistance + m_dComponentResistanceStamp);
+        dResistance = oConductanceMatrix(m_iNodeD, m_iNodeD);
+        oConductanceMatrix(m_iNodeD, m_iNodeD) = dResistance + m_dComponentResistanceStamp;
     };
 
     void Capacitor::applySourceVectorMatrixStamp(Matrix& oSourceVector) {
@@ -57,11 +58,11 @@ namespace SimulationEngine {
 
         m_dCurrent = m_dComponentResistanceStamp * (m_dVoltageDelta)+m_dCurrent; // 2C/dt*v(t-1) + i(t-1)
 
-        dCurrent = oSourceVector.getValue(m_iNodeS, 0);
-        oSourceVector.setValue(m_iNodeS, 0, dCurrent + m_dCurrent);
+        dCurrent = oSourceVector(m_iNodeS, 0);
+        oSourceVector(m_iNodeS, 0) = dCurrent + m_dCurrent;
 
-        dCurrent = oSourceVector.getValue(m_iNodeD, 0);
-        oSourceVector.setValue(m_iNodeD, 0, dCurrent - m_dCurrent);
+        dCurrent = oSourceVector(m_iNodeD, 0);
+        oSourceVector(m_iNodeD, 0) = dCurrent - m_dCurrent;
     };
 
     void Capacitor::step(Matrix& oSourceVector) { // Trapezoidal integration
@@ -69,7 +70,7 @@ namespace SimulationEngine {
     }
 
     void Capacitor::postStep(Matrix& oVoltageMatrix) {
-        m_dVoltageDelta = (oVoltageMatrix.getValue(m_iNodeS, 0) - oVoltageMatrix.getValue(m_iNodeD, 0));
+        m_dVoltageDelta = (oVoltageMatrix(m_iNodeS, 0) - oVoltageMatrix(m_iNodeD, 0));
         m_dCurrent = m_dComponentResistanceStamp * (m_dVoltageDelta) - m_dCurrent; // i(t) = 2C/dt*v(t) - 2C/dt*v(t-1) - i(t-1), m_dCurrent = 2C/dt*v(t-1) + i(t-1)
     }
 

--- a/ElectricalCircuitSimulator/SimulationEngine/src/CircuitComponent.cpp
+++ b/ElectricalCircuitSimulator/SimulationEngine/src/CircuitComponent.cpp
@@ -7,20 +7,17 @@ using std::invalid_argument;
 namespace SimulationEngine {
 
     // If the component has a ground, iNodeS is assumed to be that ground
-    CircuitComponent::CircuitComponent(const int iNodeS, const int iNodeD, bool bIsGround) {
-        if ((iNodeS < 0) || (iNodeD < 0)) {
-            cout << "Node values must be greater than or equal to 0!" << endl;
-            throw invalid_argument("Node values must be greater than or equal to 0!");
-        }
+    CircuitComponent::CircuitComponent(const size_t iNodeS, const size_t iNodeD, bool bIsGround) :
+        m_bIsGround(bIsGround),
+        m_dCurrent(0.0),
+        m_dComponentResistanceStamp(0.0)
+    {
         if (iNodeS == iNodeD) {
             cout << "Node values must not be the same!" << endl;
             throw invalid_argument("Node values must not be the same!");
         }
-        m_bIsGround = bIsGround;
         m_iNodeS = iNodeS;
         m_iNodeD = iNodeD;
-        m_dCurrent = 0.0;
-        m_dComponentResistanceStamp = 0.0;
     }
 
     void CircuitComponent::initalize(Matrix& oConductanceMatrix, const double dTimeStep) {

--- a/ElectricalCircuitSimulator/SimulationEngine/src/GroundedVoltageSource.cpp
+++ b/ElectricalCircuitSimulator/SimulationEngine/src/GroundedVoltageSource.cpp
@@ -17,8 +17,8 @@ using std::invalid_argument;
 
 namespace SimulationEngine {
 
-    GroundedVoltageSource::GroundedVoltageSource(const int iNodeS, const int iNodeD, const double dVoltage, const double dResistance)
-    : CircuitComponent(iNodeS, iNodeD, true) {
+    GroundedVoltageSource::GroundedVoltageSource(const size_t iNodeS, const size_t iNodeD, const double dVoltage, const double dResistance) :
+        CircuitComponent(iNodeS, iNodeD, true) {
         if (dResistance <= 0) {
             cout << "Resistance value must be greater than 0!" << endl;
             throw invalid_argument("Resistance value must be greater than 0!");
@@ -41,17 +41,17 @@ namespace SimulationEngine {
 
         m_dComponentResistanceStamp = 1.0 / m_dResistance;
 
-        dResistance = oConductanceMatrix.getValue(m_iNodeS, m_iNodeS);
-        oConductanceMatrix.setValue(m_iNodeS, m_iNodeS, dResistance + m_dComponentResistanceStamp);
+        dResistance = oConductanceMatrix(m_iNodeS, m_iNodeS);
+        oConductanceMatrix(m_iNodeS, m_iNodeS) = dResistance + m_dComponentResistanceStamp;
 
-        dResistance = oConductanceMatrix.getValue(m_iNodeS, m_iNodeD);
-        oConductanceMatrix.setValue(m_iNodeS, m_iNodeD, dResistance - m_dComponentResistanceStamp);
+        dResistance = oConductanceMatrix(m_iNodeS, m_iNodeD);
+        oConductanceMatrix(m_iNodeS, m_iNodeD) = dResistance - m_dComponentResistanceStamp;
 
-        dResistance = oConductanceMatrix.getValue(m_iNodeD, m_iNodeS);
-        oConductanceMatrix.setValue(m_iNodeD, m_iNodeS, dResistance - m_dComponentResistanceStamp);
+        dResistance = oConductanceMatrix(m_iNodeD, m_iNodeS);
+        oConductanceMatrix(m_iNodeD, m_iNodeS) = dResistance - m_dComponentResistanceStamp;
 
-        dResistance = oConductanceMatrix.getValue(m_iNodeD, m_iNodeD);
-        oConductanceMatrix.setValue(m_iNodeD, m_iNodeD, dResistance + m_dComponentResistanceStamp);
+        dResistance = oConductanceMatrix(m_iNodeD, m_iNodeD);
+        oConductanceMatrix(m_iNodeD, m_iNodeD) = dResistance + m_dComponentResistanceStamp;
     };
 
     void GroundedVoltageSource::applySourceVectorMatrixStamp(Matrix& oSourceVector) {
@@ -60,11 +60,11 @@ namespace SimulationEngine {
 
         dComponentCurrentStamp = m_dVoltage / m_dResistance;
 
-        dCurrent = oSourceVector.getValue(m_iNodeS, 0);
-        oSourceVector.setValue(m_iNodeS, 0, dCurrent - dComponentCurrentStamp);
+        dCurrent = oSourceVector(m_iNodeS, 0);
+        oSourceVector(m_iNodeS, 0) = dCurrent - dComponentCurrentStamp;
 
-        dCurrent = oSourceVector.getValue(m_iNodeD, 0);
-        oSourceVector.setValue(m_iNodeD, 0, dCurrent + dComponentCurrentStamp);
+        dCurrent = oSourceVector(m_iNodeD, 0);
+        oSourceVector(m_iNodeD, 0) = dCurrent + dComponentCurrentStamp;
     };
 
     void GroundedVoltageSource::step(Matrix& oSourceVector) {
@@ -72,7 +72,7 @@ namespace SimulationEngine {
     }
 
     void GroundedVoltageSource::postStep(Matrix& oVoltageMatrix) {
-        m_dCurrent = (m_dVoltage - (oVoltageMatrix.getValue(m_iNodeD, 0) - oVoltageMatrix.getValue(m_iNodeS, 0))) / m_dResistance;
+        m_dCurrent = (m_dVoltage - (oVoltageMatrix(m_iNodeD, 0) - oVoltageMatrix(m_iNodeS, 0))) / m_dResistance;
     }
 
 }

--- a/ElectricalCircuitSimulator/SimulationEngine/src/Inductor.cpp
+++ b/ElectricalCircuitSimulator/SimulationEngine/src/Inductor.cpp
@@ -18,14 +18,15 @@ using std::invalid_argument;
 
 namespace SimulationEngine {
 
-    Inductor::Inductor(const int iNodeS, const int iNodeD, const double dInductance)
-    : CircuitComponent(iNodeS, iNodeD, false) {
+    Inductor::Inductor(const size_t iNodeS, const size_t iNodeD, const double dInductance) :
+        CircuitComponent(iNodeS, iNodeD, false),
+        m_dVoltageDelta(0)
+    {
         if (dInductance <= 0) {
             cout << "Inductance value must be greater than 0!" << endl;
             throw invalid_argument("Inductance value must be greater than 0!");
         }
         m_dInductance = dInductance;
-        m_dVoltageDelta = 0;
     }
 
     void Inductor::initalize(Matrix& oConductanceMatrix, const double dTimeStep) {
@@ -39,17 +40,17 @@ namespace SimulationEngine {
 
         m_dComponentResistanceStamp = dTimeStep / (2.0 * m_dInductance);
 
-        dResistance = oConductanceMatrix.getValue(m_iNodeS, m_iNodeS);
-        oConductanceMatrix.setValue(m_iNodeS, m_iNodeS, dResistance + m_dComponentResistanceStamp);
+        dResistance = oConductanceMatrix(m_iNodeS, m_iNodeS);
+        oConductanceMatrix(m_iNodeS, m_iNodeS) = dResistance + m_dComponentResistanceStamp;
 
-        dResistance = oConductanceMatrix.getValue(m_iNodeS, m_iNodeD);
-        oConductanceMatrix.setValue(m_iNodeS, m_iNodeD, dResistance - m_dComponentResistanceStamp);
+        dResistance = oConductanceMatrix(m_iNodeS, m_iNodeD);
+        oConductanceMatrix(m_iNodeS, m_iNodeD) = dResistance - m_dComponentResistanceStamp;
 
-        dResistance = oConductanceMatrix.getValue(m_iNodeD, m_iNodeS);
-        oConductanceMatrix.setValue(m_iNodeD, m_iNodeS, dResistance - m_dComponentResistanceStamp);
+        dResistance = oConductanceMatrix(m_iNodeD, m_iNodeS);
+        oConductanceMatrix(m_iNodeD, m_iNodeS) = dResistance - m_dComponentResistanceStamp;
 
-        dResistance = oConductanceMatrix.getValue(m_iNodeD, m_iNodeD);
-        oConductanceMatrix.setValue(m_iNodeD, m_iNodeD, dResistance + m_dComponentResistanceStamp);
+        dResistance = oConductanceMatrix(m_iNodeD, m_iNodeD);
+        oConductanceMatrix(m_iNodeD, m_iNodeD) = dResistance + m_dComponentResistanceStamp;
     };
 
     void Inductor::applySourceVectorMatrixStamp(Matrix& oSourceVector) {
@@ -57,11 +58,11 @@ namespace SimulationEngine {
 
         m_dCurrent = m_dComponentResistanceStamp * m_dVoltageDelta + m_dCurrent; // dt/2L*v(t-1) + i(t-1)
 
-        dCurrent = oSourceVector.getValue(m_iNodeS, 0);
-        oSourceVector.setValue(m_iNodeS, 0, dCurrent - m_dCurrent);
+        dCurrent = oSourceVector(m_iNodeS, 0);
+        oSourceVector(m_iNodeS, 0) = dCurrent - m_dCurrent;
 
-        dCurrent = oSourceVector.getValue(m_iNodeD, 0);
-        oSourceVector.setValue(m_iNodeD, 0, dCurrent + m_dCurrent);
+        dCurrent = oSourceVector(m_iNodeD, 0);
+        oSourceVector(m_iNodeD, 0) = dCurrent + m_dCurrent;
     };
 
     void Inductor::step(Matrix& oSourceVector) { // Trapezoidal integration
@@ -69,7 +70,7 @@ namespace SimulationEngine {
     }
 
     void Inductor::postStep(Matrix& oVoltageMatrix) {
-        m_dVoltageDelta = (oVoltageMatrix.getValue(m_iNodeS, 0) - oVoltageMatrix.getValue(m_iNodeD, 0));
+        m_dVoltageDelta = (oVoltageMatrix(m_iNodeS, 0) - oVoltageMatrix(m_iNodeD, 0));
         m_dCurrent = m_dComponentResistanceStamp * m_dVoltageDelta + m_dCurrent; // i(t) = dt/2L*v(t) + dt/2L*v(t-1) + i(t-1), m_dCurrent = dt/2L*v(t-1) + i(t-1)
     }
 

--- a/ElectricalCircuitSimulator/SimulationEngine/src/Matrix.cpp
+++ b/ElectricalCircuitSimulator/SimulationEngine/src/Matrix.cpp
@@ -2,16 +2,24 @@
 
 using std::cout;
 using std::endl;
-using std::swap;
 using std::invalid_argument;
 using std::exception;
-
-#define ZERO (1e-9) // If a diagonal on the U matrix is less than or equal to this, it is considered a zero
+using std::string;
+using std::to_string;
+using std::unique_ptr;
+using std::make_unique;
+using std::swap;
 
 namespace SimulationEngine {
 
-    Matrix::Matrix(const int iRows, const int iColumns) {
-        int iRow;
+    Matrix::Matrix() :
+        m_iNumRows(0),
+        m_iNumColumns(0),
+        m_pMatrix(new double* [0])
+    { ; }
+
+    Matrix::Matrix(const size_t iRows, const size_t iColumns) {
+        size_t iRow;
 
         if ((iRows < 1) || (iColumns < 1)) {
             cout << "Matrix dimensions must be positive and non-zero!" << endl;
@@ -20,109 +28,135 @@ namespace SimulationEngine {
 
         m_iNumRows = iRows;
         m_iNumColumns = iColumns;
-        m_oMatrix = new double*[m_iNumRows];
+        m_pMatrix = new double* [m_iNumRows];
         for(iRow = 0; iRow < m_iNumRows; iRow++) {
-            m_oMatrix[iRow] = new double[m_iNumColumns];
+            m_pMatrix[iRow] = new double[m_iNumColumns];
         }
         clear();
     }
 
-    double Matrix::getValue(const int iRow, int const iColumn) const {
-        if ((iRow >= m_iNumRows) || (iColumn >= m_iNumColumns)) {
-            cout << "Location beyond dimensions of matrix!" << endl;
-            throw invalid_argument("Location beyond dimensions of matrix!");
+    Matrix::Matrix(const Matrix& oMatrix) {
+        size_t iRow;
+        size_t iColumn;
+        m_iNumRows = oMatrix.getNumRows();
+        m_iNumColumns = oMatrix.getNumColumns();
+        m_pMatrix = new double* [m_iNumRows];
+        for (iRow = 0; iRow < m_iNumRows; iRow++) {
+            m_pMatrix[iRow] = new double[m_iNumColumns];
         }
-        return m_oMatrix[iRow][iColumn];
+
+        for (iRow = 0; iRow < m_iNumRows; iRow++) {
+            for (iColumn = 0; iColumn < m_iNumColumns; iColumn++) {
+                m_pMatrix[iRow][iColumn] = oMatrix(iRow, iColumn);
+            }
+        }
     }
 
-    void Matrix::setValue(const int iRow, const int iColumn, const double dValue) {
+    double Matrix::getValue(const size_t iRow, const size_t iColumn) const {
         if ((iRow >= m_iNumRows) || (iColumn >= m_iNumColumns)) {
             cout << "Location beyond dimensions of matrix!" << endl;
             throw invalid_argument("Location beyond dimensions of matrix!");
         }
-        m_oMatrix[iRow][iColumn] = dValue;
+        return m_pMatrix[iRow][iColumn];
+    }
+
+    void Matrix::setValue(const size_t iRow, const size_t iColumn, const double dValue) {
+        if ((iRow >= m_iNumRows) || (iColumn >= m_iNumColumns)) {
+            cout << "Location beyond dimensions of matrix!" << endl;
+            throw invalid_argument("Location beyond dimensions of matrix!");
+        }
+        m_pMatrix[iRow][iColumn] = dValue;
+    }
+
+    void Matrix::swapRows(const size_t iRow1, const size_t iRow2) {
+        swap(m_pMatrix[iRow1], m_pMatrix[iRow2]);
+    }
+
+    void Matrix::swapValues(const size_t iRow1, const size_t iColumn1, const size_t iRow2, const size_t iColumn2) {
+        swap(m_pMatrix[iRow1][iColumn1], m_pMatrix[iRow2][iColumn2]);
     }
 
     void Matrix::clear() {
-        int iRow;
-        int iColumn;
+        size_t iRow;
+        size_t iColumn;
 
         for (iRow = 0; iRow < m_iNumRows; iRow++) {
             for (iColumn = 0; iColumn < m_iNumColumns; iColumn++) {
-                m_oMatrix[iRow][iColumn] = 0.0;
+                m_pMatrix[iRow][iColumn] = 0.0;
             }
         }
     }
 
-    Matrix* Matrix::clone() const {
-        int iRow;
-        int iColumn;
-        Matrix* pNewMatrix = new Matrix(m_iNumRows, m_iNumColumns);
+    const string Matrix::printMatrix() const {
+        size_t iRow;
+        size_t iColumn;
+        string sMatrix = "";
 
         for (iRow = 0; iRow < m_iNumRows; iRow++) {
-            for (iColumn = 0; iColumn < m_iNumColumns; iColumn++) {
-                pNewMatrix->m_oMatrix[iRow][iColumn] = m_oMatrix[iRow][iColumn];
-            }
-        }
-
-        return pNewMatrix;
-    }
-
-    void Matrix::printMatrix() const {
-        int iRow;
-        int iColumn;
-
-        for (iRow = 0; iRow < m_iNumRows; iRow++) {
-            cout << "[" << m_oMatrix[iRow][0];
+            sMatrix += "[" + to_string(m_pMatrix[iRow][0]);
             for (iColumn = 1; iColumn < m_iNumColumns; iColumn++) {
-                cout << "\t" << m_oMatrix[iRow][iColumn];
+                sMatrix += "\t" + to_string(m_pMatrix[iRow][iColumn]);
             }
-            cout << "]\n";
+            sMatrix += "]\n";
         }
-        cout << endl;
+        sMatrix += '\n';
+
+        return sMatrix;
+    }
+
+    PLU_Factorization::PLU_Factorization() :
+        m_pL(make_unique<Matrix>()),
+        m_pU(make_unique<Matrix>()),
+        m_pP(make_unique<Matrix>()),
+        m_pQ(make_unique<Matrix>())
+    { ; }
+
+    PLU_Factorization::PLU_Factorization(const Matrix& oMatrix) {
+        runPLU_Factorization(oMatrix);
     }
 
     // Function to perform PLU factorization with row and column pivoting
     // Factors a matrix into P*A*Q = L*U, where P = Row Permutation Matrix, and Q = Column Permutation Matrix
-    PLU_Factorization* Matrix::runPLU_Factorization() const {
-        PLU_Factorization* pResults = new PLU_Factorization();
+    void PLU_Factorization::runPLU_Factorization(const Matrix& oMatrix) {
+        size_t iRows = oMatrix.getNumRows();
+        size_t iColumns = oMatrix.getNumColumns();
         double dMaxVal;
-        int iMaxRow;
-        int iMaxCol;
-        int iI1;
-        int iI2;
-        int iI3;
+        size_t iMaxRow;
+        size_t iMaxCol;
+        size_t iI1;
+        size_t iI2;
+        size_t iI3;
 
-        if ((m_iNumRows == 0) || (m_iNumColumns == 0)) {
+        if ((iRows == 0) || (iColumns == 0)) {
             cout << "Cannot factor a matrix with dimensions of zero!" << endl;
             throw invalid_argument("Cannot factor a matrix with dimensions of zero!");
         }
 
         // Initialize P and Q as identity permutations (single column matrices)
-        pResults->m_pP = new Matrix(m_iNumRows, 1);
-        pResults->m_pQ = new Matrix(m_iNumRows, 1);
-        pResults->m_pL = new Matrix(m_iNumRows, m_iNumRows);
-        pResults->m_pU = clone(); // Initialize U to be a copy of A
+        m_pP = make_unique<Matrix>(iRows, 1);
+        m_pQ = make_unique<Matrix>(iRows, 1);
+        m_pL = make_unique<Matrix>(iRows, iRows);
+        m_pU = make_unique<Matrix>(oMatrix); // Initialize U to be a copy of A
 
         // Initialize L to an idenity matrix
-        for (iI1 = 0; iI1 < m_iNumRows; ++iI1) {
-            pResults->m_pL->m_oMatrix[iI1][iI1] = 1.0;
+        for (iI1 = 0; iI1 < iRows; ++iI1) {
+            (*m_pL)(iI1, iI1) = 1.0;
         }
 
-        for (iI1 = 0; iI1 < m_iNumRows; ++iI1) {
-            pResults->m_pP->m_oMatrix[iI1][0] = iI1;
-            pResults->m_pQ->m_oMatrix[iI1][0] = iI1;
+        for (iI1 = 0; iI1 < iRows; ++iI1) {
+            (*m_pP)(iI1, 0) = (double)iI1;
+            (*m_pQ)(iI1, 0) = (double)iI1;
         }
 
-        for (iI3 = 0; iI3 < m_iNumRows; ++iI3) {
+        for (iI3 = 0; iI3 < iRows; ++iI3) {
             // Find the pivot (maximum element) in the submatrix U[iI3:m_iNumRows][iI3:m_iNumRows]
             dMaxVal = 0.0;
             iMaxRow = iI3;
             iMaxCol = iI3;
-            for (iI1 = iI3; iI1 < m_iNumRows; ++iI1) {
-                for (iI2 = iI3; iI2 < m_iNumRows; ++iI2) {
-                    if (fabs(pResults->m_pU->m_oMatrix[iI1][iI2]) > dMaxVal) {
-                        dMaxVal = fabs(pResults->m_pU->m_oMatrix[iI1][iI2]);
+            for (iI1 = iI3; iI1 < iRows; ++iI1) {
+                for (iI2 = iI3; iI2 < iRows; ++iI2) {
+                    if (fabs((*m_pU)(iI1, iI2)) > dMaxVal) {
+                        dMaxVal = fabs((*m_pU)(iI1, iI2));
                         iMaxRow = iI1;
                         iMaxCol = iI2;
                     }
@@ -130,86 +164,29 @@ namespace SimulationEngine {
             }
 
             // Swap rows in U to move the pivot to position (iI3, iI3)
-            swap(pResults->m_pU->m_oMatrix[iI3], pResults->m_pU->m_oMatrix[iMaxRow]);
-            swap(pResults->m_pP->m_oMatrix[iI3], pResults->m_pP->m_oMatrix[iMaxRow]);
+            m_pU->swapRows(iI3, iMaxRow);
+            m_pP->swapRows(iI3, iMaxRow);
 
             // Swap columns in U to move the pivot to position (iI3, iI3)
-            for (iI1 = 0; iI1 < m_iNumRows; ++iI1) {
-                swap(pResults->m_pU->m_oMatrix[iI1][iI3], pResults->m_pU->m_oMatrix[iI1][iMaxCol]);
+            for (iI1 = 0; iI1 < iRows; ++iI1) {
+                m_pU->swapValues(iI1, iI3, iI1, iMaxCol);
             }
-            swap(pResults->m_pQ->m_oMatrix[iI3], pResults->m_pQ->m_oMatrix[iMaxCol]);
+            m_pQ->swapRows(iI3, iMaxCol);
 
             // Update L for the row swaps
             for (iI1 = 0; iI1 < iI3; ++iI1) {
-                swap(pResults->m_pL->m_oMatrix[iI3][iI1], pResults->m_pL->m_oMatrix[iMaxRow][iI1]);
+                m_pL->swapValues(iI3, iI1, iMaxRow, iI1);
             }
 
             // Compute multipliers and update U
-            for (iI1 = iI3 + 1; iI1 < m_iNumRows; ++iI1) {
-                pResults->m_pL->m_oMatrix[iI1][iI3] = pResults->m_pU->m_oMatrix[iI1][iI3] / pResults->m_pU->m_oMatrix[iI3][iI3];
-                for (iI2 = iI3 + 1; iI2 < m_iNumRows; ++iI2) {
-                    pResults->m_pU->m_oMatrix[iI1][iI2] -= pResults->m_pL->m_oMatrix[iI1][iI3] * pResults->m_pU->m_oMatrix[iI3][iI2];
+            for (iI1 = iI3 + 1; iI1 < iRows; ++iI1) {
+                (*m_pL)(iI1, iI3) = (*m_pU)(iI1, iI3) / (*m_pU)(iI3, iI3);
+                for (iI2 = iI3 + 1; iI2 < iRows; ++iI2) {
+                    (*m_pU)(iI1, iI2) = (*m_pU)(iI1, iI2) - (*m_pL)(iI1, iI3) * (*m_pU)(iI3, iI2);
                 }
-                pResults->m_pU->m_oMatrix[iI1][iI3] = 0.0;
+                (*m_pU)(iI1, iI3) = 0.0;
             }
         }
-
-        return pResults;
-    }
-
-    Matrix* Matrix::linearSystemSolver(const Matrix& oB, const PLU_Factorization& oPLU) {
-        int iI1;
-        int iI2;
-        int iIndex;
-        int iNumRows = oB.m_iNumRows;
-        Matrix oX(iNumRows, 1); // UX = Y
-        Matrix oY(iNumRows, 1); // LY = B_Permuted
-        Matrix oB_Permuted(iNumRows, 1);
-        Matrix* pX_Final = new Matrix(iNumRows, 1);
-
-        // Apply row permutations to B to get B_Permuted
-        for (iI1 = 0; iI1 < iNumRows; ++iI1) {
-            iIndex = (int)round(oPLU.m_pP->m_oMatrix[iI1][0]);
-            oB_Permuted.m_oMatrix[iI1][0] = oB.m_oMatrix[iIndex][0];
-        }
-
-        // Forward substitution to solve LY = B_Permuted
-        for (iI1 = 0; iI1 < iNumRows; ++iI1) {
-            oY.m_oMatrix[iI1][0] = oB_Permuted.m_oMatrix[iI1][0];
-            for (iI2 = 0; iI2 < iI1; ++iI2) {
-                oY.m_oMatrix[iI1][0] -= oPLU.m_pL->m_oMatrix[iI1][iI2] * oY.m_oMatrix[iI2][0];
-            }
-        }
-
-        // Backward substitution to solve UX = Y
-        for (iI1 = iNumRows - 1; iI1 >= 0; --iI1) {
-            oX.m_oMatrix[iI1][0] = oY.m_oMatrix[iI1][0];
-            for (iI2 = iI1 + 1; iI2 < iNumRows; ++iI2) {
-                oX.m_oMatrix[iI1][0] -= oPLU.m_pU->m_oMatrix[iI1][iI2] * oX.m_oMatrix[iI2][0];
-            }
-            if (fabs(oPLU.m_pU->m_oMatrix[iI1][iI1]) > ZERO) {
-                oX.m_oMatrix[iI1][0] /= oPLU.m_pU->m_oMatrix[iI1][iI1];
-            } else {
-                oX.m_oMatrix[iI1][0] = 0; // If a diagonal on the U matrix is 0, it's due to the ground node being included in the matrix, and is effectively infinity, resulting in oX = 0 for this row.
-            }
-        }
-
-        // Apply column permutations to X using Q to get X_Final
-        for (iI1 = 0; iI1 < iNumRows; ++iI1) {
-            iIndex = (int)round(oPLU.m_pQ->m_oMatrix[iI1][0]);
-            pX_Final->m_oMatrix[iIndex][0] = oX.m_oMatrix[iI1][0];
-        }
-
-#ifdef MATRIX_PRINT
-        cout << "X Vector:" << endl;
-        oX.printMatrix();
-        cout << "Y Vector:" << endl;
-        oY.printMatrix();
-        cout << "B Permuted Vector:" << endl;
-        oB_Permuted.printMatrix();
-#endif
-
-        return pX_Final;
     }
 
 }

--- a/ElectricalCircuitSimulator/SimulationEngine/src/Resistor.cpp
+++ b/ElectricalCircuitSimulator/SimulationEngine/src/Resistor.cpp
@@ -14,8 +14,9 @@ using std::invalid_argument;
 
 namespace SimulationEngine {
 
-    Resistor::Resistor(const int iNodeS, const int iNodeD, const double dResistance)
-    : CircuitComponent(iNodeS, iNodeD, false) {
+    Resistor::Resistor(const size_t iNodeS, const size_t iNodeD, const double dResistance) :
+        CircuitComponent(iNodeS, iNodeD, false)
+    {
         if (dResistance <= 0) {
             cout << "Resistance value must be greater than 0!" << endl;
             throw invalid_argument("Resistance value must be greater than 0!");
@@ -33,21 +34,21 @@ namespace SimulationEngine {
 
         m_dComponentResistanceStamp = 1.0 / m_dResistance;
 
-        dResistance = oConductanceMatrix.getValue(m_iNodeS, m_iNodeS);
-        oConductanceMatrix.setValue(m_iNodeS, m_iNodeS, dResistance + m_dComponentResistanceStamp);
+        dResistance = oConductanceMatrix(m_iNodeS, m_iNodeS);
+        oConductanceMatrix(m_iNodeS, m_iNodeS) = dResistance + m_dComponentResistanceStamp;
 
-        dResistance = oConductanceMatrix.getValue(m_iNodeS, m_iNodeD);
-        oConductanceMatrix.setValue(m_iNodeS, m_iNodeD, dResistance - m_dComponentResistanceStamp);
+        dResistance = oConductanceMatrix(m_iNodeS, m_iNodeD);
+        oConductanceMatrix(m_iNodeS, m_iNodeD) = dResistance - m_dComponentResistanceStamp;
 
-        dResistance = oConductanceMatrix.getValue(m_iNodeD, m_iNodeS);
-        oConductanceMatrix.setValue(m_iNodeD, m_iNodeS, dResistance - m_dComponentResistanceStamp);
+        dResistance = oConductanceMatrix(m_iNodeD, m_iNodeS);
+        oConductanceMatrix(m_iNodeD, m_iNodeS) = dResistance - m_dComponentResistanceStamp;
 
-        dResistance = oConductanceMatrix.getValue(m_iNodeD, m_iNodeD);
-        oConductanceMatrix.setValue(m_iNodeD, m_iNodeD, dResistance + m_dComponentResistanceStamp);
+        dResistance = oConductanceMatrix(m_iNodeD, m_iNodeD);
+        oConductanceMatrix(m_iNodeD, m_iNodeD) = dResistance + m_dComponentResistanceStamp;
     };
 
     void Resistor::postStep(Matrix& oVoltageMatrix) {
-        m_dCurrent = (oVoltageMatrix.getValue(m_iNodeS, 0) - oVoltageMatrix.getValue(m_iNodeD, 0)) / m_dResistance;
+        m_dCurrent = (oVoltageMatrix(m_iNodeS, 0) - oVoltageMatrix(m_iNodeD, 0)) / m_dResistance;
     }
 
 }

--- a/ElectricalCircuitSimulator/SimulationEngineDebugger/SimulationEngineDebugger.cpp
+++ b/ElectricalCircuitSimulator/SimulationEngineDebugger/SimulationEngineDebugger.cpp
@@ -13,19 +13,17 @@
 using namespace SimulationEngine;
 using std::cout;
 using std::endl;
+using std::make_unique;
 
 void SimulationIntegrationTestSeriesRR()
 {
     bool bDone;
-    int iSteps = 0;
+    size_t iSteps = 0;
     LinearCircuit* pLinearCircuit = new LinearCircuit(3);
-    GroundedVoltageSource* pGroundedVoltageSource = new GroundedVoltageSource(2, 1, 30, 10); // Node 2 is ground
-    Resistor* pResistor1 = new Resistor(1, 0, 10);
-    Resistor* pResistor2 = new Resistor(0, 2, 10);
 
-    pLinearCircuit->addComponent(pGroundedVoltageSource);
-    pLinearCircuit->addComponent(pResistor1);
-    pLinearCircuit->addComponent(pResistor2);
+    pLinearCircuit->addComponent(make_unique<GroundedVoltageSource>(2, 1, 30, 10)); // Node 2 is ground
+    pLinearCircuit->addComponent(make_unique<Resistor>(1, 0, 10));
+    pLinearCircuit->addComponent(make_unique<Resistor>(0, 2, 10));
     pLinearCircuit->setStopTime(10);
     pLinearCircuit->setTimeStep(1);
     pLinearCircuit->initalize();
@@ -47,23 +45,17 @@ void SimulationIntegrationTestSeriesRR()
     cout << "Current through component 2 (expect 1): " << pLinearCircuit->getCurrent(2) << endl;
 
     delete pLinearCircuit;
-    delete pGroundedVoltageSource;
-    delete pResistor1;
-    delete pResistor2;
 }
 
 void SimulationIntegrationTestSeriesRC()
 {
     bool bDone;
-    int iSteps = 0;
+    size_t iSteps = 0;
     LinearCircuit* pLinearCircuit = new LinearCircuit(3);
-    GroundedVoltageSource* pGroundedVoltageSource = new GroundedVoltageSource(2, 1, 30, 10); // Node 2 is ground
-    Resistor* pResistor = new Resistor(1, 0, 10);
-    Capacitor* pCapacitor = new Capacitor(0, 2, 0.2);
 
-    pLinearCircuit->addComponent(pGroundedVoltageSource);
-    pLinearCircuit->addComponent(pResistor);
-    pLinearCircuit->addComponent(pCapacitor);
+    pLinearCircuit->addComponent(make_unique<GroundedVoltageSource>(2, 1, 30, 10)); // Node 2 is ground
+    pLinearCircuit->addComponent(make_unique<Resistor>(1, 0, 10));
+    pLinearCircuit->addComponent(make_unique<Capacitor>(0, 2, 0.2));
     pLinearCircuit->setStopTime(10);
     pLinearCircuit->setTimeStep(1);
     pLinearCircuit->initalize();
@@ -85,23 +77,17 @@ void SimulationIntegrationTestSeriesRC()
     cout << "Current through component 2 (expect 0.13888): " << pLinearCircuit->getCurrent(2) << endl;
 
     delete pLinearCircuit;
-    delete pGroundedVoltageSource;
-    delete pResistor;
-    delete pCapacitor;
 }
 
 void SimulationIntegrationTestSeriesRL()
 {
     bool bDone;
-    int iSteps = 0;
+    size_t iSteps = 0;
     LinearCircuit* pLinearCircuit = new LinearCircuit(3);
-    GroundedVoltageSource* pGroundedVoltageSource = new GroundedVoltageSource(2, 1, 30, 10); // Node 2 is ground
-    Resistor* pResistor = new Resistor(1, 0, 10);
-    Inductor* pInductor = new Inductor(0, 2, 50);
 
-    pLinearCircuit->addComponent(pGroundedVoltageSource);
-    pLinearCircuit->addComponent(pResistor);
-    pLinearCircuit->addComponent(pInductor);
+    pLinearCircuit->addComponent(make_unique<GroundedVoltageSource>(2, 1, 30, 10)); // Node 2 is ground
+    pLinearCircuit->addComponent(make_unique<Resistor>(1, 0, 10));
+    pLinearCircuit->addComponent(make_unique<Inductor>(0, 2, 50));
     pLinearCircuit->setStopTime(10);
     pLinearCircuit->setTimeStep(1);
     pLinearCircuit->initalize();
@@ -123,9 +109,6 @@ void SimulationIntegrationTestSeriesRL()
     cout << "Current through component 2 (expect 1.46748): " << pLinearCircuit->getCurrent(2) << endl;
 
     delete pLinearCircuit;
-    delete pGroundedVoltageSource;
-    delete pResistor;
-    delete pInductor;
 }
 
 int main()

--- a/ElectricalCircuitSimulator/SimulationEngineWrapper/include/SimulationEngineWrapper.h
+++ b/ElectricalCircuitSimulator/SimulationEngineWrapper/include/SimulationEngineWrapper.h
@@ -8,9 +8,6 @@
 #include "Matrix.h"
 #include "Resistor.h"
 
-using namespace System;
-using namespace SimulationEngine;
-
 namespace SimulationEngineWrapper {
 
     template<class T>
@@ -18,9 +15,9 @@ namespace SimulationEngineWrapper {
 
         public:
 
-            ManagedObject(T* pInstance) : m_pInstance(pInstance) {
-                ;
-            }
+            ManagedObject(T* pInstance) :
+                m_pInstance(pInstance)
+            { ; }
 
             virtual ~ManagedObject() {
                 if (m_pInstance != nullptr) {
@@ -33,7 +30,7 @@ namespace SimulationEngineWrapper {
                 }
             }
 
-            T* getInstance() {
+            const T& getInstance() {
                 return m_pInstance;
             }
 
@@ -43,28 +40,28 @@ namespace SimulationEngineWrapper {
 
     };
         
-    public ref class PLU_Factorization : public ManagedObject<SimulationEngine::PLU_Factorization> {
+    public ref class PLU_Factorization : ManagedObject<SimulationEngine::PLU_Factorization> {
 
         public:
 
-            PLU_Factorization() 
-            : ManagedObject(new SimulationEngine::PLU_Factorization()) { ; }
+            PLU_Factorization() :
+                ManagedObject(new SimulationEngine::PLU_Factorization()) { ; }
     };
 
-    public ref class Matrix : public ManagedObject<SimulationEngine::Matrix> {
+    public ref class Matrix : ManagedObject<SimulationEngine::Matrix> {
 
         public:
 
-            Matrix()
-            : ManagedObject(new SimulationEngine::Matrix()) { ; }
-            Matrix(const int iRows, const int iColumns)
-            : ManagedObject(new SimulationEngine::Matrix(iRows, iColumns)) { ; }
+            Matrix() :
+                ManagedObject(new SimulationEngine::Matrix()) { ; }
+            Matrix(const int iRows, const int iColumns) :
+                ManagedObject(new SimulationEngine::Matrix(iRows, iColumns)) { ; }
 
             int getNumRows() { 
-                return m_pInstance->getNumRows();
+                return (int)(m_pInstance->getNumRows());
             }
             int getNumColumns() {
-                return m_pInstance->getNumRows();
+                return (int)(m_pInstance->getNumRows());
             }
             double getValue(const int iRow, const int iColumn) {
                 return m_pInstance->getValue(iRow, iColumn);
@@ -72,86 +69,83 @@ namespace SimulationEngineWrapper {
             void setValue(const int iRow, const int iColumn, const double dValue) {
                 m_pInstance->setValue(iRow, iColumn, dValue);
             }
+            void swapRows(const int iRow1, const int iRow2) {
+                m_pInstance->swapRows(iRow1, iRow2);
+            }
+            void swapValues(const int iRow1, const int iColumn1, const int iRow2, const int iColumn2) {
+                m_pInstance->swapValues(iRow1, iColumn1, iRow2, iColumn2);
+            }
             void clear() {
                 m_pInstance->clear();
-            }
-            void clone() {
-                SimulationEngine::Matrix* pClone;
-                pClone = m_pInstance->clone();
-                delete pClone;
             }
             void printMatrix() {
                 m_pInstance->printMatrix();
             }
     };
 
-    public ref class Capacitor : public ManagedObject<SimulationEngine::Capacitor> {
+    public ref class Capacitor : ManagedObject<SimulationEngine::Capacitor> {
 
         public:
 
-            Capacitor(const int iNodeS, const int iNodeD, const double m_dCapacitance)
-            : ManagedObject(new SimulationEngine::Capacitor(iNodeS, iNodeD, m_dCapacitance)) { ; }
+            Capacitor(const int iNodeS, const int iNodeD, const double m_dCapacitance) :
+                ManagedObject(new SimulationEngine::Capacitor(iNodeS, iNodeD, m_dCapacitance)) { ; }
     };
 
-    public ref class CircuitComponent : public ManagedObject<SimulationEngine::CircuitComponent> {
+    public ref class CircuitComponent : ManagedObject<SimulationEngine::CircuitComponent> {
 
         public:
 
-            CircuitComponent(const int iNodeS, const int iNodeD, bool bIsGround)
-            : ManagedObject(new SimulationEngine::CircuitComponent(iNodeS, iNodeD, bIsGround)) { ; }
+            CircuitComponent(const int iNodeS, const int iNodeD, bool bIsGround) :
+                ManagedObject(new SimulationEngine::CircuitComponent(iNodeS, iNodeD, bIsGround)) { ; }
 
             bool getIsGround() {
                 return m_pInstance->getIsGround();
             }
             int getNodeS() {
-                return m_pInstance->getNodeS();
+                return (int)(m_pInstance->getNodeS());
             }
             int getNodeD() {
-                return m_pInstance->getNodeD();
+                return (int)(m_pInstance->getNodeD());
             }
             double getCurrent() {
                 return m_pInstance->getCurrent();
             }
     };
 
-    public ref class GroundedVoltageSource : public ManagedObject<SimulationEngine::GroundedVoltageSource> {
+    public ref class GroundedVoltageSource : ManagedObject<SimulationEngine::GroundedVoltageSource> {
         
         public:
 
-            GroundedVoltageSource(const int iNodeS, const int iNodeD, const double dVoltage, const double dResistance)
-            : ManagedObject(new SimulationEngine::GroundedVoltageSource(iNodeS, iNodeD, dVoltage, dResistance)) { ; }
+            GroundedVoltageSource(const int iNodeS, const int iNodeD, const double dVoltage, const double dResistance) :
+                ManagedObject(new SimulationEngine::GroundedVoltageSource(iNodeS, iNodeD, dVoltage, dResistance)) { ; }
     };
 
-    public ref class Inductor : public ManagedObject<SimulationEngine::Inductor> {
+    public ref class Inductor : ManagedObject<SimulationEngine::Inductor> {
         
         public:
 
-            Inductor(const int iNodeS, const int iNodeD, const double m_dInductance)
-            : ManagedObject(new SimulationEngine::Inductor(iNodeS, iNodeD, m_dInductance)) { ; }
+            Inductor(const int iNodeS, const int iNodeD, const double m_dInductance) :
+                ManagedObject(new SimulationEngine::Inductor(iNodeS, iNodeD, m_dInductance)) { ; }
     };
         
-    public ref class LinearCircuit : public ManagedObject<SimulationEngine::LinearCircuit> {
+    public ref class LinearCircuit : ManagedObject<SimulationEngine::LinearCircuit> {
 
         public:
 
-            LinearCircuit(const int iNumComponents)
-            : ManagedObject(new SimulationEngine::LinearCircuit(iNumComponents)) { ; }
+            LinearCircuit(const int iNumComponents) :
+                ManagedObject(new SimulationEngine::LinearCircuit(iNumComponents)) { ; }
 
             int addResistor(const int iNodeS, const int iNodeD, const double dResistance) {
-                SimulationEngine::Resistor* pResistor = new SimulationEngine::Resistor(iNodeS, iNodeD, dResistance);
-                return m_pInstance->addComponent(pResistor);
+                return (int)(m_pInstance->addComponent(std::make_unique<SimulationEngine::Resistor>(iNodeS, iNodeD, dResistance)));
             }
             int addInductor(const int iNodeS, const int iNodeD, const double dInductance) {
-                SimulationEngine::Inductor* pInductor = new SimulationEngine::Inductor(iNodeS, iNodeD, dInductance);
-                return m_pInstance->addComponent(pInductor);
+                return (int)(m_pInstance->addComponent(std::make_unique<SimulationEngine::Inductor>(iNodeS, iNodeD, dInductance)));
             }
             int addCapacitor(const int iNodeS, const int iNodeD, const double dCapacitance) {
-                SimulationEngine::Capacitor* pCapacitor = new::Capacitor(iNodeS, iNodeD, dCapacitance);
-                return m_pInstance->addComponent(pCapacitor);
+                return (int)(m_pInstance->addComponent(std::make_unique<SimulationEngine::Capacitor>(iNodeS, iNodeD, dCapacitance)));
             }
             int addGroundedVoltageSource(const int iNodeS, const int iNodeD, const double dVoltage, const double dResistance) {
-                SimulationEngine::GroundedVoltageSource* pGroundedVoltageSource = new SimulationEngine::GroundedVoltageSource(iNodeS, iNodeD, dVoltage, dResistance);
-                return m_pInstance->addComponent(pGroundedVoltageSource);
+                return (int)(m_pInstance->addComponent(std::make_unique<SimulationEngine::GroundedVoltageSource>(iNodeS, iNodeD, dVoltage, dResistance)));
             }
             void setStopTime(const double dStopTime) {
                 m_pInstance->setStopTime(dStopTime);
@@ -176,11 +170,11 @@ namespace SimulationEngineWrapper {
             }
     };
 
-    public ref class Resistor : public ManagedObject<SimulationEngine::Resistor> {
+    public ref class Resistor : ManagedObject<SimulationEngine::Resistor> {
 
         public:
 
-            Resistor(const int iNodeS, const int iNodeD, const double dResistance)
-            : ManagedObject(new SimulationEngine::Resistor(iNodeS, iNodeD, dResistance)) { ; }
+            Resistor(const int iNodeS, const int iNodeD, const double dResistance) :
+                ManagedObject(new SimulationEngine::Resistor(iNodeS, iNodeD, dResistance)) { ; }
     };
 }

--- a/ElectricalCircuitSimulator/UnitTests/UnitTests.cs
+++ b/ElectricalCircuitSimulator/UnitTests/UnitTests.cs
@@ -165,7 +165,13 @@ namespace UnitTests
             int iColumn;
 
             Matrix oMatrix = new Matrix();
-            oMatrix = new Matrix(2, 6);
+            oMatrix = new Matrix(3, 6);
+            oMatrix.setValue(0, 1, 1);
+            oMatrix.setValue(2, 3, 2);
+            oMatrix.swapRows(0, 2);
+            Assert.IsTrue(oMatrix.getValue(0, 3) == 2 && oMatrix.getValue(2, 1) == 1, "Incorrect matrix values! Expected row swap!");
+            oMatrix.swapValues(0, 3, 2, 1);
+            Assert.IsTrue(oMatrix.getValue(0, 3) == 1 && oMatrix.getValue(2, 1) == 2, "Incorrect matrix values! Expected value swap!");
             AssertAction.VerifyAssert(() => oMatrix = new Matrix(0, 5), "Expected 'Matrix dimensions must be positive and non-zero!' error, did not get it!");
             AssertAction.VerifyAssert(() => oMatrix = new Matrix(6, 0), "Expected 'Matrix dimensions must be positive and non-zero!' error, did not get it!");
             AssertAction.VerifyAssert(() => oMatrix = new Matrix(-6, 6), "Expected 'Matrix dimensions must be positive and non-zero!' error, did not get it!");
@@ -202,7 +208,6 @@ namespace UnitTests
                     Assert.IsTrue((int)Math.Round(oMatrix.getValue(iRow, iColumn)) == 0, "Incorrect matrix value! Expected 0");
                 }
             }
-            oMatrix.clone();
             oMatrix.Dispose();
         }
 
@@ -220,8 +225,7 @@ namespace UnitTests
             CircuitComponent oCircuitComponent;
 
             AssertAction.VerifyAssert(() => oCircuitComponent = new CircuitComponent(5, 5, false), "Expected 'Node values must not be the same!' error, did not get it!");
-            AssertAction.VerifyAssert(() => oCircuitComponent = new CircuitComponent(0, -6, false), "Expected 'Node values must be greater than or equal to 0!' error, did not get it!");
-            AssertAction.VerifyAssert(() => oCircuitComponent = new CircuitComponent(-5, 6, false), "Expected 'Node values must be greater than or equal to 0!' error, did not get it!");
+            AssertAction.VerifyAssert(() => oCircuitComponent = new CircuitComponent(0, 0, false), "Expected 'Node values must be greater than or equal to 0!' error, did not get it!");
 
             oCircuitComponent = new CircuitComponent(0, 5, false);
             Assert.IsTrue(oCircuitComponent.getIsGround() == false, "Incorrect value! Expected false");

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Electrical Circuit Simulator
 ## Running the Software
-- To run the software, download the latest release off Github.
+- To run the software, download the latest release off Github. If you don't already have it, you will be prompted to install the .NET 8.0 desktop runtime first.
 ## About the Software
 - Electrical Circuit Simulator is an app that can simulate electrical circuits via converting them into resistance/current matrices, and then solving for the node voltages via PLU matrix factorization.
 - Note that Electrical Circuit Simulator is not a marketing term or a brand name, but simply a description of what the app does.


### PR DESCRIPTION
- No public data members.
- No public exposure of instance variable pointers, and no public exposure of other pointers except for smart pointers being given to objects for them to manage.
- No non-const references to instance variables returned.
- Adhere to RAII.
- Ahere to rule of 0 and the rule of 5.
- Remove all 'using' statements from .h files.
- Mark classes as final if they are not expected to be used for inheritance.
- Use size_t instead of int when unsigned integers are required.
- Overload the '()' operator on the matrix class so it can be used to read and write to the matrix.
- Move the linearSystemSolver function to the LinearCircuit class, and rename it 'solver'.
- Removed direct console prints from the printMatrix function.
- Several things were not done that could be done if C++ CLI were not being used: 1) Make the Matrix class into a template. 2) Operator overloading in the C++ -> C# wrapper. 3) C++ CLI wrappers do not support RAII or Rule of 5. 4) Eliminate get/set functions for the Matrix class.